### PR TITLE
fix(validator): allow header deserialization

### DIFF
--- a/src/PSR7/SpecFinder.php
+++ b/src/PSR7/SpecFinder.php
@@ -247,7 +247,7 @@ final class SpecFinder
             }
 
             $headerData = json_decode(json_encode($p->getSerializableData()), true);
-            unset($headerData['in'], $headerData['name']);
+            unset($headerData['name']);
             try {
                 $headerSpecs[$p->name] = new HeaderSpec($headerData);
             } catch (TypeErrorException $e) {


### PR DESCRIPTION
This PR allows us to provide better header validation on complex header.

For header value which can be like "key1=value1,key2=value", it will be deserialize into
```php
[
  "key1" => "value1",
  "key2" => "value2"
]
```

and then be correctly match with openapi declaration like:
```yaml
    - name: Pagination
      in: header
      required: true
      style: simple
      explode: true
      schema:
        type: object
        required:
          - key1
          - key2
        properties:
          key1:
            type: integer
            example: 1
          key2:
            type: integer
            example: 10
```

Please note, part of the forked lib seems weird at first glance since some validators wait for array to check object type.
I will continue to look for more information as soon as possible.