### PR TITLE
fix(validation): preserve JSON container types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ jobs:
   tests:
     name: Tests
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
@@ -15,53 +14,45 @@ jobs:
           - "lowest"
           - "highest"
         php:
-          - '7.2'
-          - '7.3'
-          - '7.4'
-          - '8.0'
-        experimental:
-          - false
-        include:
-          - php: "8.1"
-            composer-options: "--ignore-platform-reqs"
-            experimental: true
-            dependencies: "highest"
+          - '8.1'
+          - '8.2'
+          - '8.3'
+          - '8.4'
 
     steps:
       - name: Set up PHP
-        uses: shivammathur/setup-php@2.9.0
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           extensions: intl, mbstring
           tools: "composer:v2"
 
       - name: Checkout code
-        uses: actions/checkout@v2
-
+        uses: actions/checkout@v4
 
       - name: "Install lowest dependencies"
         if: ${{ matrix.dependencies == 'lowest' }}
-        run: composer update --prefer-lowest --no-interaction --no-progress --no-suggest ${{ matrix.composer-options }}
+        run: composer update --prefer-lowest --no-interaction --no-progress
 
       - name: "Install highest dependencies"
         if: ${{ matrix.dependencies == 'highest' }}
-        run: composer update --no-interaction --no-progress --no-suggest ${{ matrix.composer-options }}
+        run: composer update --no-interaction --no-progress
 
       - name: "Run tests"
         run: ./vendor/bin/phpunit -c phpunit.xml
 
   cs:
-    name: Codestyle check on PHP 7.2
+    name: Codestyle check on PHP 8.1
     runs-on: ubuntu-latest
 
     steps:
       - name: Set up PHP
-        uses: shivammathur/setup-php@2.1.0
+        uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.2
+          php-version: 8.1
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Download dependencies
         run: composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
@@ -76,16 +67,16 @@ jobs:
     strategy:
       matrix:
         php:
-          - '7.2'
+          - '8.1'
 
     steps:
       - name: Set up PHP
-        uses: shivammathur/setup-php@2.1.0
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Download dependencies
         run: composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     },
     "require": {
-        "php": ">=7.2",
+        "php": ">=8.1",
         "ext-json": "*",
         "devizzent/cebe-php-openapi": "^1.0",
         "giggsey/libphonenumber-for-php": "^9.0",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    phpVersion: 70200
+    phpVersion: 80100
     level: 6
     paths:
         - src

--- a/src/PSR7/OperationAddress.php
+++ b/src/PSR7/OperationAddress.php
@@ -70,7 +70,7 @@ class OperationAddress
 
     public function countPlaceholders(): int
     {
-        return preg_match_all(self::PATH_PLACEHOLDER, $this->path()) ?? 0;
+        return preg_match_all(self::PATH_PLACEHOLDER, $this->path()) ?: 0;
     }
 
     public function countExactMatchParts(string $comparisonPath): int

--- a/src/PSR7/Validators/BodyValidator/BodyValidator.php
+++ b/src/PSR7/Validators/BodyValidator/BodyValidator.php
@@ -7,6 +7,7 @@ namespace OpenClassrooms\OpenAPIValidation\PSR7\Validators\BodyValidator;
 use cebe\openapi\spec\MediaType;
 use cebe\openapi\spec\Reference;
 use cebe\openapi\spec\RequestBody;
+use cebe\openapi\spec\Response as ResponseSpec;
 use OpenClassrooms\OpenAPIValidation\PSR7\Exception\Validation\InvalidBody;
 use OpenClassrooms\OpenAPIValidation\PSR7\Exception\Validation\InvalidHeaders;
 use OpenClassrooms\OpenAPIValidation\PSR7\MessageValidator;
@@ -53,7 +54,9 @@ final class BodyValidator implements MessageValidator
             return;
         }
 
-        $mediaTypeSpecs = $mediaTypeSpecs->content;
+        /** @var RequestBody|ResponseSpec $bodySpec */
+        $bodySpec       = $mediaTypeSpecs;
+        $mediaTypeSpecs = $bodySpec->content;
 
         if (empty($mediaTypeSpecs)) {
             // edge case: if "content" keyword is not set (body can be anything as no expectations set)

--- a/src/PSR7/Validators/BodyValidator/MultipartValidator.php
+++ b/src/PSR7/Validators/BodyValidator/MultipartValidator.php
@@ -171,7 +171,7 @@ class MultipartValidator implements MessageValidator
             $partContentType = $part->getHeader('Content-Type');
 
             if (! empty($partContentType) && preg_match('#^application/.*json$#', $partContentType)) {
-                $partBody = json_decode($part->getBody(), true);
+                $partBody = json_decode($part->getBody());
                 if (json_last_error() !== JSON_ERROR_NONE) {
                     throw InvalidBody::becauseBodyIsNotValidJson(json_last_error_msg(), $addr);
                 }

--- a/src/PSR7/Validators/BodyValidator/UnipartValidator.php
+++ b/src/PSR7/Validators/BodyValidator/UnipartValidator.php
@@ -44,7 +44,7 @@ class UnipartValidator implements MessageValidator
     public function validate(OperationAddress $addr, MessageInterface $message): void
     {
         if (preg_match('#^application/.*json$#', $this->contentType)) {
-            $body = json_decode((string) $message->getBody(), true);
+            $body = json_decode((string) $message->getBody());
             if (json_last_error() !== JSON_ERROR_NONE) {
                 throw InvalidBody::becauseBodyIsNotValidJson(json_last_error_msg(), $addr);
             }

--- a/src/PSR7/Validators/PathValidator.php
+++ b/src/PSR7/Validators/PathValidator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenClassrooms\OpenAPIValidation\PSR7\Validators;
 
+use LogicException;
 use OpenClassrooms\OpenAPIValidation\PSR7\Exception\NoPath;
 use OpenClassrooms\OpenAPIValidation\PSR7\Exception\Validation\InvalidParameter;
 use OpenClassrooms\OpenAPIValidation\PSR7\Exception\Validation\InvalidPath;
@@ -11,7 +12,6 @@ use OpenClassrooms\OpenAPIValidation\PSR7\Exception\Validation\RequiredParameter
 use OpenClassrooms\OpenAPIValidation\PSR7\MessageValidator;
 use OpenClassrooms\OpenAPIValidation\PSR7\OperationAddress;
 use OpenClassrooms\OpenAPIValidation\PSR7\SpecFinder;
-use LogicException;
 use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\RequestInterface;
 

--- a/src/PSR7/Validators/SerializedParameter.php
+++ b/src/PSR7/Validators/SerializedParameter.php
@@ -278,9 +278,9 @@ final class SerializedParameter
             throw TypeMismatch::becauseTypeDoesNotMatch(['iterable'], $value);
         }
 
-        $array  = [];
+        $array = [];
         foreach ($value as &$val) {
-            $splitVal = explode('=', $val);
+            $splitVal            = explode('=', $val);
             $array[$splitVal[0]] = $this->castToSchemaType($splitVal[1], $schema->properties[$splitVal[0]]->type ?? null);
         }
 

--- a/src/Schema/Keywords/Type.php
+++ b/src/Schema/Keywords/Type.php
@@ -52,7 +52,7 @@ class Type extends BaseKeyword
         foreach ($types as $type) {
             switch ($type) {
                 case CebeType::OBJECT:
-                    if (! is_object($data) && ! (is_array($data) && ArrayHelper::isAssoc($data)) && $data !== []) {
+                    if (! is_object($data) && ! (is_array($data) && ArrayHelper::isAssoc($data))) {
                         break;
                     }
 

--- a/src/Schema/Keywords/Type.php
+++ b/src/Schema/Keywords/Type.php
@@ -52,7 +52,7 @@ class Type extends BaseKeyword
         foreach ($types as $type) {
             switch ($type) {
                 case CebeType::OBJECT:
-                    if (! is_object($data) && ! (is_array($data) && ArrayHelper::isAssoc($data))) {
+                    if (! is_object($data) && ! (is_array($data) && ArrayHelper::isAssoc($data)) && $data !== []) {
                         break;
                     }
 

--- a/src/Schema/SchemaValidator.php
+++ b/src/Schema/SchemaValidator.php
@@ -129,7 +129,7 @@ final class SchemaValidator implements Validator
             }
 
             if (isset($schema->enum)) {
-                (new Enum($schema))->validate($data, $schema->enum);
+                (new Enum($schema))->validate($objectData, $schema->enum);
             }
 
             if (isset($schema->items)) {

--- a/src/Schema/SchemaValidator.php
+++ b/src/Schema/SchemaValidator.php
@@ -31,7 +31,9 @@ use OpenClassrooms\OpenAPIValidation\Schema\Keywords\Type;
 use OpenClassrooms\OpenAPIValidation\Schema\Keywords\UniqueItems;
 
 use function count;
+use function get_object_vars;
 use function is_array;
+use function is_object;
 
 // This will load a whole schema and data to validate if one matches another
 final class SchemaValidator implements Validator
@@ -68,6 +70,8 @@ final class SchemaValidator implements Validator
             if (isset($schema->type)) {
                 (new Type($schema))->validate($data, $schema->type, $schema->format);
             }
+
+            $objectData = is_object($data) ? get_object_vars($data) : $data;
 
             // This keywords come directly from JSON Schema Validation, they are the same as in JSON schema
             // https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5
@@ -110,15 +114,18 @@ final class SchemaValidator implements Validator
             }
 
             if (isset($schema->maxProperties)) {
-                (new MaxProperties($schema))->validate($data, $schema->maxProperties);
+                (new MaxProperties($schema))->validate($objectData, $schema->maxProperties);
             }
 
             if (isset($schema->minProperties)) {
-                (new MinProperties($schema))->validate($data, $schema->minProperties);
+                (new MinProperties($schema))->validate($objectData, $schema->minProperties);
             }
 
             if (isset($schema->required)) {
-                (new Required($schema, $this->validationStrategy, $breadCrumb))->validate($data, $schema->required);
+                (new Required($schema, $this->validationStrategy, $breadCrumb))->validate(
+                    $objectData,
+                    $schema->required
+                );
             }
 
             if (isset($schema->enum)) {
@@ -131,12 +138,15 @@ final class SchemaValidator implements Validator
 
             if (
                 $schema->type === CebeType::OBJECT
-                || (isset($schema->properties) && is_array($data) && ArrayHelper::isAssoc($data))
+                || (
+                    isset($schema->properties)
+                    && (is_object($data) || (is_array($data) && ArrayHelper::isAssoc($data)))
+                )
             ) {
                 $additionalProperties = $schema->additionalProperties ?? null; // defaults to true
                 if ((isset($schema->properties) && count($schema->properties)) || $additionalProperties) {
                     (new Properties($schema, $this->validationStrategy, $breadCrumb))->validate(
-                        $data,
+                        $objectData,
                         $schema->properties,
                         $additionalProperties
                     );

--- a/src/Schema/TypeFormats/StringSafeURI.php
+++ b/src/Schema/TypeFormats/StringSafeURI.php
@@ -7,6 +7,20 @@ namespace OpenClassrooms\OpenAPIValidation\Schema\TypeFormats;
 use League\Uri\Exceptions\SyntaxError;
 use League\Uri\UriString;
 
+use function count;
+use function ctype_digit;
+use function explode;
+use function filter_var;
+use function in_array;
+use function is_int;
+use function preg_match;
+use function str_contains;
+use function str_ends_with;
+use function strlen;
+use function strtolower;
+
+use const FILTER_VALIDATE_IP;
+
 class StringSafeURI
 {
     private const ALLOWED_SCHEMES = ['https'];
@@ -20,12 +34,12 @@ class StringSafeURI
             return false;
         }
 
-        if (!isset($parts['scheme'], $parts['host'])) {
+        if (! isset($parts['scheme'], $parts['host'])) {
             return false;
         }
 
-        $scheme = strtolower((string)$parts['scheme']);
-        if (!in_array($scheme, self::ALLOWED_SCHEMES, true)) {
+        $scheme = strtolower((string) $parts['scheme']);
+        if (! in_array($scheme, self::ALLOWED_SCHEMES, true)) {
             return false;
         }
 
@@ -37,11 +51,11 @@ class StringSafeURI
             return false;
         }
 
-        if (isset($parts['port']) && !$this->isAllowedPort($parts['port'])) {
+        if (isset($parts['port']) && ! $this->isAllowedPort($parts['port'])) {
             return false;
         }
 
-        $host = strtolower((string)$parts['host']);
+        $host = strtolower((string) $parts['host']);
         if ($host === '' || $this->isLocalHost($host) || $this->containsEncodedControlChars($host)) {
             return false;
         }
@@ -62,7 +76,7 @@ class StringSafeURI
             return $port === 443;
         }
 
-        return ctype_digit($port) && (int)$port === 443;
+        return ctype_digit($port) && (int) $port === 443;
     }
 
     private function isLocalHost(string $host): bool

--- a/tests/FromCommunity/JsonContainerTypeValidationTest.php
+++ b/tests/FromCommunity/JsonContainerTypeValidationTest.php
@@ -11,6 +11,8 @@ use OpenClassrooms\OpenAPIValidation\PSR7\ServerRequestValidator;
 use OpenClassrooms\OpenAPIValidation\PSR7\ValidatorBuilder;
 use PHPUnit\Framework\TestCase;
 
+use function implode;
+
 final class JsonContainerTypeValidationTest extends TestCase
 {
     /**
@@ -23,6 +25,7 @@ final class JsonContainerTypeValidationTest extends TestCase
             'empty object' => ['/objects', '{}'],
             'nested empty array' => ['/nested-arrays', '{"value":[]}'],
             'nested empty object' => ['/nested-objects', '{"value":{}}'],
+            'object enum' => ['/object-enums', '{"kind":"x"}'],
         ];
     }
 
@@ -59,6 +62,48 @@ final class JsonContainerTypeValidationTest extends TestCase
         $this->validator()->validate($this->request($path, $body));
     }
 
+    /**
+     * @return mixed[][]
+     */
+    public function validMultipartBodyProvider(): array
+    {
+        return [
+            'empty array' => ['/multipart-arrays', '[]'],
+            'empty object' => ['/multipart-objects', '{}'],
+        ];
+    }
+
+    /**
+     * @dataProvider validMultipartBodyProvider
+     */
+    public function testItPreservesJsonContainerTypesInMultipartBodies(string $path, string $body): void
+    {
+        $this->validator()->validate($this->multipartRequest($path, $body));
+
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @return mixed[][]
+     */
+    public function invalidMultipartBodyProvider(): array
+    {
+        return [
+            'object is not an array' => ['/multipart-arrays', '{}'],
+            'array is not an object' => ['/multipart-objects', '[]'],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidMultipartBodyProvider
+     */
+    public function testItRejectsTheWrongJsonContainerTypeInMultipartBodies(string $path, string $body): void
+    {
+        $this->expectException(InvalidBody::class);
+
+        $this->validator()->validate($this->multipartRequest($path, $body));
+    }
+
     private function validator(): ServerRequestValidator
     {
         return (new ValidatorBuilder())->fromYaml($this->schema())->getServerRequestValidator();
@@ -69,6 +114,24 @@ final class JsonContainerTypeValidationTest extends TestCase
         return (new ServerRequest('post', 'http://localhost' . $path))
             ->withHeader('Content-Type', 'application/json')
             ->withBody(Utils::streamFor($body));
+    }
+
+    private function multipartRequest(string $path, string $body): ServerRequest
+    {
+        $boundary      = 'json-container-boundary';
+        $multipartBody = implode("\r\n", [
+            '--' . $boundary,
+            'Content-Disposition: form-data; name="value"',
+            'Content-Type: application/json',
+            '',
+            $body,
+            '--' . $boundary . '--',
+            '',
+        ]);
+
+        return (new ServerRequest('post', 'http://localhost' . $path))
+            ->withHeader('Content-Type', 'multipart/form-data; boundary=' . $boundary)
+            ->withBody(Utils::streamFor($multipartBody));
     }
 
     private function schema(): string
@@ -126,6 +189,51 @@ paths:
         required: true
         content:
           application/json:
+            schema:
+              type: object
+              required: [value]
+              properties:
+                value:
+                  type: object
+      responses:
+        '204':
+          description: No content
+  /object-enums:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              enum:
+                - kind: x
+      responses:
+        '204':
+          description: No content
+  /multipart-arrays:
+    post:
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [value]
+              properties:
+                value:
+                  type: array
+                  items:
+                    type: string
+      responses:
+        '204':
+          description: No content
+  /multipart-objects:
+    post:
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
             schema:
               type: object
               required: [value]

--- a/tests/FromCommunity/JsonContainerTypeValidationTest.php
+++ b/tests/FromCommunity/JsonContainerTypeValidationTest.php
@@ -23,8 +23,10 @@ final class JsonContainerTypeValidationTest extends TestCase
         return [
             'empty array' => ['/arrays', '[]'],
             'empty object' => ['/objects', '{}'],
+            'empty array accepted for object compatibility' => ['/objects', '[]'],
             'nested empty array' => ['/nested-arrays', '{"value":[]}'],
             'nested empty object' => ['/nested-objects', '{"value":{}}'],
+            'nested empty array accepted for object compatibility' => ['/nested-objects', '{"value":[]}'],
             'object enum' => ['/object-enums', '{"kind":"x"}'],
         ];
     }
@@ -46,9 +48,9 @@ final class JsonContainerTypeValidationTest extends TestCase
     {
         return [
             'object is not an array' => ['/arrays', '{}'],
-            'array is not an object' => ['/objects', '[]'],
+            'non-empty array is not an object' => ['/objects', '[1]'],
             'nested object is not an array' => ['/nested-arrays', '{"value":{}}'],
-            'nested array is not an object' => ['/nested-objects', '{"value":[]}'],
+            'nested non-empty array is not an object' => ['/nested-objects', '{"value":[1]}'],
         ];
     }
 
@@ -70,6 +72,7 @@ final class JsonContainerTypeValidationTest extends TestCase
         return [
             'empty array' => ['/multipart-arrays', '[]'],
             'empty object' => ['/multipart-objects', '{}'],
+            'empty array accepted for object compatibility' => ['/multipart-objects', '[]'],
         ];
     }
 
@@ -90,7 +93,7 @@ final class JsonContainerTypeValidationTest extends TestCase
     {
         return [
             'object is not an array' => ['/multipart-arrays', '{}'],
-            'array is not an object' => ['/multipart-objects', '[]'],
+            'non-empty array is not an object' => ['/multipart-objects', '[1]'],
         ];
     }
 

--- a/tests/FromCommunity/JsonContainerTypeValidationTest.php
+++ b/tests/FromCommunity/JsonContainerTypeValidationTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenClassrooms\OpenAPIValidation\Tests\FromCommunity;
+
+use GuzzleHttp\Psr7\ServerRequest;
+use GuzzleHttp\Psr7\Utils;
+use OpenClassrooms\OpenAPIValidation\PSR7\Exception\Validation\InvalidBody;
+use OpenClassrooms\OpenAPIValidation\PSR7\ServerRequestValidator;
+use OpenClassrooms\OpenAPIValidation\PSR7\ValidatorBuilder;
+use PHPUnit\Framework\TestCase;
+
+final class JsonContainerTypeValidationTest extends TestCase
+{
+    /**
+     * @return mixed[][]
+     */
+    public function validBodyProvider(): array
+    {
+        return [
+            'empty array' => ['/arrays', '[]'],
+            'empty object' => ['/objects', '{}'],
+            'nested empty array' => ['/nested-arrays', '{"value":[]}'],
+            'nested empty object' => ['/nested-objects', '{"value":{}}'],
+        ];
+    }
+
+    /**
+     * @dataProvider validBodyProvider
+     */
+    public function testItPreservesJsonContainerTypes(string $path, string $body): void
+    {
+        $this->validator()->validate($this->request($path, $body));
+
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @return mixed[][]
+     */
+    public function invalidBodyProvider(): array
+    {
+        return [
+            'object is not an array' => ['/arrays', '{}'],
+            'array is not an object' => ['/objects', '[]'],
+            'nested object is not an array' => ['/nested-arrays', '{"value":{}}'],
+            'nested array is not an object' => ['/nested-objects', '{"value":[]}'],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidBodyProvider
+     */
+    public function testItRejectsTheWrongJsonContainerType(string $path, string $body): void
+    {
+        $this->expectException(InvalidBody::class);
+
+        $this->validator()->validate($this->request($path, $body));
+    }
+
+    private function validator(): ServerRequestValidator
+    {
+        return (new ValidatorBuilder())->fromYaml($this->schema())->getServerRequestValidator();
+    }
+
+    private function request(string $path, string $body): ServerRequest
+    {
+        return (new ServerRequest('post', 'http://localhost' . $path))
+            ->withHeader('Content-Type', 'application/json')
+            ->withBody(Utils::streamFor($body));
+    }
+
+    private function schema(): string
+    {
+        return <<<'YAML'
+openapi: 3.0.0
+info:
+  title: JSON container validation
+  version: '1.0'
+paths:
+  /arrays:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: object
+      responses:
+        '204':
+          description: No content
+  /objects:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '204':
+          description: No content
+  /nested-arrays:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [value]
+              properties:
+                value:
+                  type: array
+                  items:
+                    type: string
+      responses:
+        '204':
+          description: No content
+  /nested-objects:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [value]
+              properties:
+                value:
+                  type: object
+      responses:
+        '204':
+          description: No content
+YAML;
+    }
+}

--- a/tests/Schema/Keywords/TypeTest.php
+++ b/tests/Schema/Keywords/TypeTest.php
@@ -19,7 +19,9 @@ final class TypeTest extends SchemaValidatorTest
         return [
             ['string', null, 'string value'],
             ['object', null, ['a' => 1]],
+            ['object', null, new stdClass()],
             ['array', null, ['a', 'b']],
+            ['array', null, []],
             ['boolean', null, true],
             ['boolean', null, false],
             ['number', null, 12],
@@ -77,7 +79,9 @@ SPEC;
         return [
             ['string', 12],
             ['object', 'not object'],
+            ['object', []],
             ['array', ['a' => 1, 'b' => 2]], // this is not a plain array (a-la JSON)
+            ['array', new stdClass()],
             ['boolean', [1, 2]],
             ['boolean', 'True'],
             ['boolean', ''],

--- a/tests/Schema/Keywords/TypeTest.php
+++ b/tests/Schema/Keywords/TypeTest.php
@@ -19,6 +19,7 @@ final class TypeTest extends SchemaValidatorTest
         return [
             ['string', null, 'string value'],
             ['object', null, ['a' => 1]],
+            ['object', null, []],
             ['object', null, new stdClass()],
             ['array', null, ['a', 'b']],
             ['array', null, []],
@@ -79,7 +80,7 @@ SPEC;
         return [
             ['string', 12],
             ['object', 'not object'],
-            ['object', []],
+            ['object', [1]],
             ['array', ['a' => 1, 'b' => 2]], // this is not a plain array (a-la JSON)
             ['array', new stdClass()],
             ['boolean', [1, 2]],


### PR DESCRIPTION
## Summary

- preserve JSON object and array types for regular and multipart bodies
- reject `{}` for array schemas
- keep accepting `[]` for object schemas for backward compatibility
- normalize decoded objects for object keywords and enums
- align the declared PHP support and CI matrix with PHP 8.1+

## Tests

- PHPUnit: 506 tests, 590 assertions
- PHPStan
- PHPCS
- Composer validation
- lowest and highest dependency sets
- GitHub CI: 20/20 checks pass